### PR TITLE
Set dependencies to scope=provided

### DIFF
--- a/jaeger/pom.xml
+++ b/jaeger/pom.xml
@@ -34,11 +34,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-opentracing-jaeger-common</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
       <version>${jaeger.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 
@@ -46,7 +48,7 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
+        <artifactId>maven-assembly-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -131,14 +132,21 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.1</version>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.1.1</version>
           <executions>
             <execution>
+              <id>jar-with-dependencies</id>
               <phase>package</phase>
               <goals>
-                <goal>shade</goal>
+                <goal>single</goal>
               </goals>
+              <configuration>
+                <descriptors>
+                  <descriptor>assembly.xml</descriptor>
+                </descriptors>
+                <appendAssemblyId>false</appendAssemblyId>
+              </configuration>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
Currently, the dependency graph of `jaeger-client-bundle` includes its dependencies in scope=compile. When an upstream dependent of `jaeger-client-bundle` analyzes its dependency graph, the graph will include each of these dependencies with scope=compile. However, the `jaeger-client-bundle` is a "fat-jar" shaded bundle, which includes all of the classes of its dependencies inside it. Therefore, the original dependencies should not be on the dependency graph.

The SpecialAgent is an upstream dependent of `jaeger-client-bundle`, and analyzes the dependency graph of its dependencies to determine which JARs need to be bundled with the SpecialAgent. Since the `jaeger-client-bundle` declares its dependencies with scope=compile, the SpecialAgent includes these JARs, unnecessarily.

This PR fixes the dependency graph for `jaeger-client-bundle` by declaring its dependencies as scope=provided, and using a different mechanism to create the shaded "uber-jar" (because the maven-shade-plugin does not have a mechanism to shade dependencies with scope=provided, but the maven-assembly-plugin does).