### PR TITLE
Set dependency scope=provided

### DIFF
--- a/jaeger/assembly.xml
+++ b/jaeger/assembly.xml
@@ -1,0 +1,30 @@
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>jar-with-dependencies</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>provided</scope>
+      <excludes>
+        <exclude>io.opentracing:opentracing-api</exclude>
+        <exclude>io.opentracing:opentracing-util</exclude>
+        <exclude>io.opentracing:opentracing-noop</exclude>
+        <exclude>io.opentracing.contrib:opentracing-tracerresolver</exclude>
+      </excludes>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>runtime</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/jaeger/pom.xml
+++ b/jaeger/pom.xml
@@ -34,11 +34,13 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>java-opentracing-jaeger-common</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
       <version>${jaeger.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 
@@ -46,7 +48,7 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
+        <artifactId>maven-assembly-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -131,14 +132,21 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.1</version>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.1.1</version>
           <executions>
             <execution>
+              <id>jar-with-dependencies</id>
               <phase>package</phase>
               <goals>
-                <goal>shade</goal>
+                <goal>single</goal>
               </goals>
+              <configuration>
+                <descriptors>
+                  <descriptor>assembly.xml</descriptor>
+                </descriptors>
+                <appendAssemblyId>false</appendAssemblyId>
+              </configuration>
             </execution>
           </executions>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -156,72 +156,71 @@
     <plugins>
       <!-- Ensures checksums are added to published jars -->
       <plugin>
-	<artifactId>maven-install-plugin</artifactId>
-	<version>${maven-install-plugin.version}</version>
-	<configuration>
-	  <createChecksum>true</createChecksum>
-	</configuration>
+      	<artifactId>maven-install-plugin</artifactId>
+      	<version>${maven-install-plugin.version}</version>
+      	<configuration>
+      	  <createChecksum>true</createChecksum>
+      	</configuration>
       </plugin>
       <plugin>
-	<artifactId>maven-release-plugin</artifactId>
-	<version>${maven-release-plugin.version}</version>
-	<configuration>
-	  <useReleaseProfile>false</useReleaseProfile>
-	  <releaseProfiles>release</releaseProfiles>
-	  <autoVersionSubmodules>true</autoVersionSubmodules>
-	  <tagNameFormat>@{project.version}</tagNameFormat>
-	</configuration>
+      	<artifactId>maven-release-plugin</artifactId>
+      	<version>${maven-release-plugin.version}</version>
+      	<configuration>
+      	  <useReleaseProfile>false</useReleaseProfile>
+      	  <releaseProfiles>release</releaseProfiles>
+      	  <autoVersionSubmodules>true</autoVersionSubmodules>
+      	  <tagNameFormat>@{project.version}</tagNameFormat>
+      	</configuration>
       </plugin>
       <plugin>
-	<groupId>io.zipkin.centralsync-maven-plugin</groupId>
-	<artifactId>centralsync-maven-plugin</artifactId>
-	<version>${centralsync-maven-plugin.version}</version>
-	<configuration>
-	  <subject>opentracing</subject>
-	  <repo>maven</repo>
+      	<groupId>io.zipkin.centralsync-maven-plugin</groupId>
+      	<artifactId>centralsync-maven-plugin</artifactId>
+      	<version>${centralsync-maven-plugin.version}</version>
+      	<configuration>
+      	  <subject>opentracing</subject>
+      	  <repo>maven</repo>
           <packageName>opentracing-jaeger-client-bundle</packageName>
-	</configuration>
+      	</configuration>
       </plugin>
     </plugins>
-
   </build>
 
   <profiles>
     <profile>
       <id>release</id>
       <build>
-	<plugins>
-	  <!-- Creates source jar -->
-	  <plugin>
-	    <artifactId>maven-source-plugin</artifactId>
-	    <version>${maven-source-plugin.version}</version>
-	    <executions>
-	      <execution>
-		<id>attach-sources</id>
-		<goals>
-		  <goal>jar</goal>
-		</goals>
-	      </execution>
-	    </executions>
-	  </plugin>
-	  <!-- Creates javadoc jar -->
-	  <plugin>
-	    <artifactId>maven-javadoc-plugin</artifactId>
-	    <version>${maven-javadoc-plugin.version}</version>
-	    <configuration>
-	      <failOnError>false</failOnError>
-	    </configuration>
-	    <executions>
-	      <execution>
-		<id>attach-javadocs</id>
-		<goals>
-		  <goal>jar</goal>
-		</goals>
-		<phase>package</phase>
-	      </execution>
-	    </executions>
-	  </plugin>
-	</plugins>
+      	<plugins>
+      	  <!-- Creates source jar -->
+      	  <plugin>
+      	    <artifactId>maven-source-plugin</artifactId>
+      	    <version>${maven-source-plugin.version}</version>
+      	    <executions>
+      	      <execution>
+            		<id>attach-sources</id>
+            		<goals>
+            		  <goal>jar</goal>
+            		</goals>
+      	      </execution>
+      	    </executions>
+      	  </plugin>
+      	  <!-- Creates javadoc jar -->
+      	  <plugin>
+      	    <artifactId>maven-javadoc-plugin</artifactId>
+      	    <version>${maven-javadoc-plugin.version}</version>
+      	    <configuration>
+      	      <failOnError>false</failOnError>
+      	    </configuration>
+      	    <executions>
+      	      <execution>
+            		<id>attach-javadocs</id>
+            		<goals>
+            		  <goal>jar</goal>
+            		</goals>
+            		<phase>package</phase>
+      	      </execution>
+      	    </executions>
+      	  </plugin>
+      	</plugins>
       </build>
     </profile>
   </profiles>


### PR DESCRIPTION
Currently, the dependency graph of jaeger-client-bundle includes its dependencies in scope=compile. When an upstream dependent of jaeger-client-bundle analyzes its dependency graph, the graph will include each of these dependencies with scope=compile. However, the jaeger-client-bundle is a "fat-jar" shaded bundle, which includes all of the classes of its dependencies inside it. Therefore, the original dependencies should not be on the dependency graph.

The SpecialAgent is an upstream dependent of jaeger-client-bundle, and analyzes the dependency graph of its dependencies to determine which JARs need to be bundled with the SpecialAgent. Since the jaeger-client-bundle declares its dependencies with scope=compile, the SpecialAgent includes these JARs, unnecessarily.

This PR fixes the dependency graph for jaeger-client-bundle by declaring its dependencies as scope=provided, and using a different mechanism to create the shaded "uber-jar" (because the maven-shade-plugin does not have a mechanism to shade dependencies with scope=provided, but the maven-assembly-plugin does).

Additionally, this PR removes the OT dependencies from the assembly. The problem this solves is as follows:

The Jaeger Tracer Plugin is a plugin that is intended to be "plugged in" to an environment that provides the necessary OT APIs. Since the Jaeger Tracer Plugin currently includes all of these APIs by itself, the presence of these classes on the classpath end up masking the classes included by the hosting environment.