### PR TITLE
Update to jaeger 1.2.0

### DIFF
--- a/jaeger/pom.xml
+++ b/jaeger/pom.xml
@@ -27,7 +27,7 @@
   <name>Jaeger Client Bundle</name>
 
   <properties>
-    <jaeger.version>1.0.0</jaeger.version>
+    <jaeger.version>1.2.0</jaeger.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Jaeger < 1.2.0 has a critical bug which causes the client stop working.

The problem has been fixed at 1.2.0

https://github.com/jaegertracing/jaeger-client-java/pull/670